### PR TITLE
feat(luasnip): <c-l> to change_choice in select mode

### DIFF
--- a/xdg_config/nvim/after/plugin/luasnip.lua
+++ b/xdg_config/nvim/after/plugin/luasnip.lua
@@ -339,7 +339,7 @@ end, { silent = true })
 
 -- <c-l> is selecting within a list of options.
 -- This is useful for choice nodes (introduced in the forthcoming episode 2)
-vim.keymap.set("i", "<c-l>", function()
+vim.keymap.set({ "i", "s" }, "<c-l>", function()
   if ls.choice_active() then
     ls.change_choice(1)
   end


### PR DESCRIPTION
Hello. First of all, thank you for sharing your config here and your youtube videos. I find them incredible useful!

Situation:
I got to a strange situation when I was playing with `choice_nodes`, I was able to iterate over all the choices with <c-l> until I jumped on a choice with an `insert node` and <c-l> stopped working. Then I realized that (at least in my machine), luasnipt was changing to SELECT mode on the and <c-l> wasnt set for select mode either.

example to reproduce:
```
local ls = require"luasnip"

local s = ls.s
local sn = ls.snippet_node
local t = ls.text_node
local i = ls.insert_node
local c = ls.choice_node

snips = {
  s({
    trig = "forrange_without_insert",
    name = "for _, a := range X {...}",
  },{
    t("for "), c(1, { 
      t("_, e "),
      t("i, e "),
      t("i"),
    }), t(" := range "), i(2), t({" {", "\t"}),
    i(3),
    t({"","}",""}),
  }),

  s({
    trig = "forrange",
    name = "for _, a := range X {...}",
  },{
    t("for "), c(1, {
      sn(nil, {t("_, "), i(1,"e")}),
      sn(nil, {t("i, "), i(1,"e")}),
      t("i"),
    }), t(" := range "), i(2), t({" {", "\t"}),
    i(3),
    t({"","}",""}),
  }),
}

ls.add_snippets("example", snips, {key = "example"})

```



Of course, you can do whatever you want with your configuration and disregard this PR, I just created it in case it can be useful for you or other people like me that used part of your configuration as a starting point.

Thank you

